### PR TITLE
Changed input from Symfony to prevent it from catching the input args from launchpad cli

### DIFF
--- a/inc/Services/StraussApplication.php
+++ b/inc/Services/StraussApplication.php
@@ -4,6 +4,7 @@ namespace LaunchpadTakeOff\Services;
 
 use BrianHenryIE\Strauss\Console\Commands\Compose;
 use Symfony\Component\Console\Input\ArgvInput;
+use Symfony\Component\Console\Input\StringInput;
 use Symfony\Component\Console\Output\ConsoleOutput;
 use Symfony\Component\Console\Application;
 class StraussApplication extends Application
@@ -19,7 +20,7 @@ class StraussApplication extends Application
 
         $this->setDefaultCommand('compose');
 
-        $input = new ArgvInput();
+        $input = new StringInput('');
         $output = new ConsoleOutput();
 
         $this->doRunCommand($composeCommand, $input, $output);


### PR DESCRIPTION
Fix a bug due to the fact the Synfony CLI called by Strauss is catching the args from the Launchpad CLI and crash.